### PR TITLE
refactor: 8, 9주차 피드백 반영하여 수정

### DIFF
--- a/src/main/java/com/hhplus/tdd/concert/application/usecase/ConcertPaymentUseCase.java
+++ b/src/main/java/com/hhplus/tdd/concert/application/usecase/ConcertPaymentUseCase.java
@@ -63,6 +63,8 @@ public class ConcertPaymentUseCase {
         concertReservationRepository.saveAll(concertReservation);
 
         int totalPrice = concertPayments.stream().mapToInt(ConcertPayment::getPaymentAmount).sum();
+        deductUserPoints(totalPrice, concertPaymentReq.getUserId());
+
         ConcertPaymentResult result = ConcertPaymentResult.of(totalPrice);
 
         Map<String, Object> eventData = Map.of(

--- a/src/main/java/com/hhplus/tdd/concert/domain/kafka/MessageProducer.java
+++ b/src/main/java/com/hhplus/tdd/concert/domain/kafka/MessageProducer.java
@@ -1,0 +1,7 @@
+package com.hhplus.tdd.concert.domain.kafka;
+
+import com.hhplus.tdd.concert.domain.model.ConcertEvent;
+
+public interface MessageProducer {
+    void send(ConcertEvent event, String eventId);
+}

--- a/src/main/java/com/hhplus/tdd/concert/event/ConcertEventListener.java
+++ b/src/main/java/com/hhplus/tdd/concert/event/ConcertEventListener.java
@@ -2,11 +2,10 @@ package com.hhplus.tdd.concert.event;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hhplus.tdd.balance.domain.repository.BalanceRepository;
+import com.hhplus.tdd.concert.domain.kafka.MessageProducer;
 import com.hhplus.tdd.concert.domain.model.ConcertEvent;
 import com.hhplus.tdd.concert.domain.model.Outbox;
 import com.hhplus.tdd.concert.domain.service.OutboxService;
-import com.hhplus.tdd.concert.infra.kafka.producer.KafkaMessageProducer;
 import com.hhplus.tdd.waitingqueue.domain.model.WaitingQueue;
 import com.hhplus.tdd.waitingqueue.domain.repository.WaitingQueueRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,10 +23,9 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class ConcertEventListener {
 
     private final WaitingQueueRepository waitingQueueRepository;
-    private final BalanceRepository balanceRepository;
 
     private final OutboxService outboxService;
-    private final KafkaMessageProducer kafkaMessageProducer;
+    private final MessageProducer messageProducer;
     private final ObjectMapper objectMapper;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -60,7 +58,7 @@ public class ConcertEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Async
     public void sendkafka(ConcertEvent event) {
-        kafkaMessageProducer.send(event, event.getEventId());
+        messageProducer.send(event, event.getEventId());
         log.info("send kafka ");
     }
 }

--- a/src/main/java/com/hhplus/tdd/concert/infra/kafka/producer/KafkaMessageProducer.java
+++ b/src/main/java/com/hhplus/tdd/concert/infra/kafka/producer/KafkaMessageProducer.java
@@ -2,6 +2,7 @@ package com.hhplus.tdd.concert.infra.kafka.producer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hhplus.tdd.concert.domain.model.ConcertEvent;
+import com.hhplus.tdd.concert.domain.kafka.MessageProducer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -10,19 +11,19 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class KafkaMessageProducer {
+public class KafkaMessageProducer implements MessageProducer {
 
     private final KafkaTemplate<String, String> kafkaTemplate;
-
     private final ObjectMapper objectMapper;
 
+    @Override
     public void send(ConcertEvent event, String eventId) {
         try {
             String jsonObject = objectMapper.writeValueAsString(event);
             kafkaTemplate.send("payment_completed_topic", eventId, jsonObject);
-            log.info("send payment eamil event: " + event);
+            log.info("send payment email event: " + event);
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("Failed to send Kafka message", e);
         }
     }
 }

--- a/src/main/java/com/hhplus/tdd/concert/scheduler/ConcertScheduler.java
+++ b/src/main/java/com/hhplus/tdd/concert/scheduler/ConcertScheduler.java
@@ -2,8 +2,8 @@ package com.hhplus.tdd.concert.scheduler;
 
 import com.hhplus.tdd.concert.domain.model.ConcertEvent;
 import com.hhplus.tdd.concert.domain.model.Outbox;
+import com.hhplus.tdd.concert.domain.kafka.MessageProducer;
 import com.hhplus.tdd.concert.domain.service.OutboxService;
-import com.hhplus.tdd.concert.infra.kafka.producer.KafkaMessageProducer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -17,7 +17,7 @@ import java.util.List;
 public class ConcertScheduler {
 
     private final OutboxService outboxService;
-    private final KafkaMessageProducer kafkaMessageProducer;
+    private final MessageProducer messageProducer;
 
     @Scheduled(fixedRate = 60000)
     public void retryScheduler() {
@@ -28,7 +28,7 @@ public class ConcertScheduler {
         if (outboxes != null) {
             for (int i = 0; i < outboxes.size(); i++) {
                 ConcertEvent event = ConcertEvent.toRetryCompleteEvent(outboxes.get(i).getEventId(), outboxes.get(i));
-                kafkaMessageProducer.send(event, outboxes.get(i).getEventId());
+                messageProducer.send(event, outboxes.get(i).getEventId());
             }
         }
     }


### PR DESCRIPTION
8주차 피드백 내용(Step16):
- 현 상황에서 포인트 차감 로직을 적절한 보상트랜잭션 없이 분리하는건 위험할 수 있다고 봅니다. 하나의 트랜잭션에서 처리할 수 있도록 하면 어떨까요? 만약 관심사는 분리하고 싶은거라면 AFTER_COMMIT 대신에 BEFORE_COMMIT 으로 변경

9주차 피드백 내용(Step18):
- kafkaMessageProducer 가 DIP 가 지켜지면 좋지 않을까요?